### PR TITLE
sfos: Automatically restart mpris-proxy service if it crashes

### DIFF
--- a/rpm/mpris-proxy.service
+++ b/rpm/mpris-proxy.service
@@ -6,6 +6,8 @@ After=lipstick.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/mpris-proxy
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=post-user-session.target


### PR DESCRIPTION
[sailfish] Automatically restart mpris-proxy service if it crashes. Fixes JB#58244