### PR TITLE
sfos: Remove dependency to hwdata. JB#62529

### DIFF
--- a/rpm/bluez5.spec
+++ b/rpm/bluez5.spec
@@ -13,7 +13,6 @@ Source4:    obexd.tracing
 Source5:    mpris-proxy.service
 Requires:   %{name}-libs = %{version}-%{release}
 Requires:   dbus >= 0.60
-Requires:   hwdata >= 0.215
 Requires:   bluez5-configs
 Requires:   systemd
 Requires:   oneshot


### PR DESCRIPTION
Seems unnecessary, not spotting usage.
Also fedora packaging removed a similar dependency, even matching the version, in 2013.